### PR TITLE
Make navbar sticky under header when scroll. Add useElementHeight Hook

### DIFF
--- a/src/components/common/Layout/Header/Header.tsx
+++ b/src/components/common/Layout/Header/Header.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, ForwardedRef } from 'react'
 import * as S from './styled'
 import { Typography as T } from '../../../../core/typography'
 
@@ -6,15 +6,17 @@ type Props = {
   title: string
   subtitle?: string
   actions?: ReactNode
+  forwardedRef?: ForwardedRef<HTMLDivElement>
 }
 
 export default function BaseLayout({
   title = 'Title',
   subtitle = '',
   actions,
+  forwardedRef,
 }: Props) {
   return (
-    <S.Header role="banner">
+    <S.Header role="banner" ref={forwardedRef}>
       <div>
         <T.Heading3 bold>{title}</T.Heading3>
         <T.BodySmall>{subtitle}</T.BodySmall>

--- a/src/components/common/organisms/Tabs/Tabs.tsx
+++ b/src/components/common/organisms/Tabs/Tabs.tsx
@@ -7,9 +7,13 @@ export type TabItem = {
   content: React.ReactNode
 }
 
-type Props = { items: TabItem[]; defaultKey?: string }
+type Props = {
+  items: TabItem[]
+  defaultKey?: string
+  offset: number
+}
 
-export default function Tabs({ items, defaultKey }: Props) {
+export default function Tabs({ items, defaultKey, offset }: Props) {
   const keys = items.map((i) => i.key)
   const [active, setActive] = useState(defaultKey ?? keys[0])
 
@@ -28,7 +32,12 @@ export default function Tabs({ items, defaultKey }: Props) {
 
   return (
     <>
-      <S.Bar role="tablist" aria-label="Sections" onKeyDown={onKeyDown}>
+      <S.Bar
+        role="tablist"
+        aria-label="Sections"
+        onKeyDown={onKeyDown}
+        offset={offset} // <-- now forwarded
+      >
         {items.map((t) => {
           const isActive = t.key === active
           return (

--- a/src/components/common/organisms/Tabs/styled.ts
+++ b/src/components/common/organisms/Tabs/styled.ts
@@ -4,11 +4,16 @@ import tokens from '../../../../core/tokens'
 const DIVIDER_W = `${tokens.size.BASELINE / 8}px`
 const INDICATOR_H = '2px'
 
-export const Bar = styled.nav`
+export const Bar = styled.nav<{ offset: number }>`
   display: flex;
   gap: ${tokens.gap.LARGE}px;
   margin: ${tokens.spacing.BASELINE * 2}px 0 ${tokens.spacing.BASELINE}px;
   border-bottom: ${DIVIDER_W} solid ${({ theme }) => theme.colors.scrollBar};
+  background: ${({ theme }) => theme.colors.primaryBackground};
+
+  position: sticky;
+  top: ${({ offset }) => offset}px;
+  z-index: 10;
 `
 
 export const TabButton = styled.button<{ active: boolean }>`

--- a/src/hooks/useElementHeight.ts
+++ b/src/hooks/useElementHeight.ts
@@ -1,0 +1,19 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
+export function useElementHeight<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  const [height, setHeight] = useState(0)
+
+  useLayoutEffect(() => {
+    if (!ref.current) return
+
+    const updateHeight = () => setHeight(ref.current?.offsetHeight || 0)
+
+    updateHeight()
+
+    window.addEventListener('resize', updateHeight)
+    return () => window.removeEventListener('resize', updateHeight)
+  }, [])
+
+  return { ref, height }
+}

--- a/src/pages/LiberyPage/index.tsx
+++ b/src/pages/LiberyPage/index.tsx
@@ -2,17 +2,21 @@ import Tabs from '../../components/common/organisms/Tabs'
 import { PaddedContainer } from '../../components/common/styled'
 import { LIBRARY_TABS } from './tabs.config'
 import Header from '../../components/common/Layout/Header'
+import { useElementHeight } from '../../hooks/useElementHeight'
 
 export default function LibraryPage() {
+  const { ref, height } = useElementHeight<HTMLDivElement>()
+
   return (
     <>
       <Header
         title="React-Vite Template"
         subtitle="Explore reusable components, hooks, and patterns"
+        forwardedRef={ref}
       />
 
       <PaddedContainer>
-        <Tabs items={LIBRARY_TABS} defaultKey="overview" />
+        <Tabs offset={height} items={LIBRARY_TABS} defaultKey="overview" />
       </PaddedContainer>
     </>
   )


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->
This PR makes the navbar sticky under the header when scrolling. It adds useElementHeight to get the header height dynamically, making the behavior stable and responsive.
- Added useElementHeight hook to measure header height dynamically using ResizeObserver.
- Updated Tabs → forwards offset prop to S.Bar for sticky positioning.
- Refactored S.Bar to use top: ${({ offset }) => offset}px instead of hardcoded value.
- Ensures navbar always sticks directly under the header on both desktop and mobile.

## How to test

1.  Install and start the project:

    - `npm install`
    - `npm run dev`

2.  Open local host
    - Resize the browser window to a smaller height and scroll down.
    - Verify that the navbar sticks directly under the header.
    - Repeat the same test in mobile view (browser dev tools or real device).

## Type of Change

<!-- Mark the appropriate option with an "x" (no spaces around the x) -->

- [x] `feature`: New feature
- [ ] `chore`: Maintenance, dependency updates, or refactoring
- [ ] `test`: Adding or improving tests
- [ ] `bug`: Bug fix
- [ ] `docs`: Documentation updates
- [ ] Other (please specify):

## Shortcut story

<!-- Add the link to the Shortcut story (e.g., http://app.shortcut.com/arne-ai/story/44/privacy-links-mvp-version) -->
https://trello.com/c/d4b6xYI6/22-bug-text-shown-under-header-when-scrolling-on-page

## Related Issues

<!-- Link any related issues that this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Testing Performed

<!-- Describe the testing you've performed to validate your changes -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to help explain your changes -->
<img width="782" height="663" alt="Screenshot 2025-08-28 at 12 36 10" src="https://github.com/user-attachments/assets/17843a14-927b-4624-94dd-938363146d5c" />
<img width="319" height="570" alt="Screenshot 2025-08-28 at 12 36 27" src="https://github.com/user-attachments/assets/5f52b20d-b676-4d1c-9957-0ec97c69807a" />

## Checklist

<!-- Mark completed items with an "x" (no spaces around the x) -->

- [x] My code follows the project's coding style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All existing and new tests pass
- [x] I have checked for and resolved any merge conflicts
- [ ] I have made corresponding changes to the README (if applicable)

## Additional Notes

<!-- Any additional information or context that would be helpful for reviewers -->
